### PR TITLE
Fix GitHub CLI extension installation - update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,16 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
+          - goos: linux
+            goarch: 386
           - goos: darwin
             goarch: amd64
           - goos: darwin
             goarch: arm64
           - goos: windows
             goarch: amd64
+          - goos: windows
+            goarch: 386
 
     steps:
       - name: Checkout
@@ -79,7 +83,7 @@ jobs:
             EXT=".exe"
           fi
           
-          BINARY_NAME="gh-issue-dependency-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}"
+          BINARY_NAME="gh-issue-dependency-${{ matrix.goos }}-${{ matrix.goarch }}${EXT}"
           
           go build \
             -ldflags "-s -w -X cmd.Version=${{ steps.version.outputs.version }} -X cmd.Commit=${GITHUB_SHA:0:8} -X cmd.BuildType=release" \


### PR DESCRIPTION
## Summary

Fixes GitHub CLI extension installation by updating the release workflow to generate properly named binaries.

### Problem
- `gh extension install torynet/gh-issue-dependency` was failing with "no usable release artifact found"
- Binary names included version numbers which GitHub CLI doesn't recognize
- Missing some common architectures

### Solution
- **Fixed binary naming**: Removed version from binary names to match GitHub CLI extension requirements
  - Before: `gh-issue-dependency-v1.0.0-linux-amd64`
  - After: `gh-issue-dependency-linux-amd64`
- **Added more architectures**: Added 32-bit Windows and Linux support
- **Verified installation**: Tested with manual release v0.1.1

### Test Results
✅ **Extension installation now works**:
```bash
$ gh extension install torynet/gh-issue-dependency
# (succeeds silently)

$ gh issue-dependency --help
# (shows help output)
```

### Binary Naming Convention
Following [GitHub CLI extension requirements](https://docs.github.com/en/github-cli/github-cli/creating-github-cli-extensions):
- `gh-issue-dependency-windows-amd64.exe`
- `gh-issue-dependency-windows-386.exe`  
- `gh-issue-dependency-linux-amd64`
- `gh-issue-dependency-linux-386`
- `gh-issue-dependency-darwin-amd64`
- `gh-issue-dependency-darwin-arm64`

### Supported Platforms
- Windows (64-bit and 32-bit)
- Linux (64-bit and 32-bit)  
- macOS (Intel and Apple Silicon)

## Related Issues

Closes #41

With this fix, the primary installation method documented in #39 now works correctly.